### PR TITLE
AkihiroSuda/containerd-fuse-overlayfs -> containerd/fuse-overlayfs-snapshotter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,22 @@ on:
     branches:
       - master
 jobs:
+  project:
+    name: Project Checks
+    runs-on: ubuntu-20.04
+    timeout-minutes: 20
+    steps:
+    - uses: actions/setup-go@v2
+      with:
+        go-version: 1.16.x
+    - uses: actions/checkout@v2
+      with:
+        path: src/github.com/containerd/fuse-overlayfs-snapshotter
+        fetch-depth: 25
+    - uses: containerd/project-checks@v1
+      with:
+        working-directory: src/github.com/containerd/fuse-overlayfs-snapshotter
+
  test:
     runs-on: ubuntu-20.04
     timeout-minutes: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,20 +16,20 @@ jobs:
         go-version: 1.16.x
     - uses: actions/checkout@v2
       with:
-        path: go/src/github.com/AkihiroSuda/containerd-fuse-overlayfs
+        path: go/src/github.com/containerd/fuse-overlayfs-snapshotter
     - name: "Compile binaries"
-      working-directory:  go/src/github.com/AkihiroSuda/containerd-fuse-overlayfs
+      working-directory:  go/src/github.com/containerd/fuse-overlayfs-snapshotter
       run: make artifacts
     - name: "SHA256SUMS"
-      working-directory:  go/src/github.com/AkihiroSuda/containerd-fuse-overlayfs
+      working-directory:  go/src/github.com/containerd/fuse-overlayfs-snapshotter
       run: |
         ( cd _output; sha256sum containerd-fuse-overlayfs-* ) | tee /tmp/SHA256SUMS
         mv /tmp/SHA256SUMS _output/SHA256SUMS
     - name: "The sha256sum of the SHA256SUMS file"
-      working-directory:  go/src/github.com/AkihiroSuda/containerd-fuse-overlayfs
+      working-directory:  go/src/github.com/containerd/fuse-overlayfs-snapshotter
       run: (cd _output; sha256sum SHA256SUMS)
     - name: "Prepare the release note"
-      working-directory:  go/src/github.com/AkihiroSuda/containerd-fuse-overlayfs
+      working-directory:  go/src/github.com/containerd/fuse-overlayfs-snapshotter
       run: |
         tag="${GITHUB_REF##*/}"
         shasha=$(sha256sum _output/SHA256SUMS | awk '{print $1}')
@@ -44,7 +44,7 @@ jobs:
         The sha256sum of the SHA256SUMS file itself is \`${shasha}\` .
         EOF
     - name: "Create release"
-      working-directory:  go/src/github.com/AkihiroSuda/containerd-fuse-overlayfs
+      working-directory:  go/src/github.com/containerd/fuse-overlayfs-snapshotter
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,17 @@
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 ARG FUSEOVERLAYFS_COMMIT=master
 ARG ROOTLESSKIT_COMMIT=v0.14.0
 ARG SHADOW_COMMIT=4.8.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ ARG DEBIAN_VERSION=10
 ARG ALPINE_VERSION=3.13
 
 FROM golang:${GO_VERSION}-alpine AS containerd-fuse-overlayfs-test
-COPY . /go/src/github.com/AkihiroSuda/containerd-fuse-overlayfs
-WORKDIR  /go/src/github.com/AkihiroSuda/containerd-fuse-overlayfs
+COPY . /go/src/github.com/containerd/fuse-overlayfs-snapshotter
+WORKDIR  /go/src/github.com/containerd/fuse-overlayfs-snapshotter
 ENV CGO_ENABLED=0
 ENV GO111MODULE=on
 RUN mkdir /out && go test -c -o /out/containerd-fuse-overlayfs.test

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,4 @@
+# fuse-overlayfs-snapshotter maintainers
+#
+# As a containerd sub-project, containerd maintainers are also included from https://github.com/containerd/project/blob/master/MAINTAINERS.
+# See https://github.com/containerd/project/blob/master/GOVERNANCE.md for description of maintainer role

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ VERSION=$(shell git describe --match 'v[0-9]*' --dirty='.m' --always --tags)
 VERSION_TRIMMED := $(VERSION:v%=%)
 REVISION=$(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi)
 
-PKG_MAIN := github.com/AkihiroSuda/containerd-fuse-overlayfs/cmd/containerd-fuse-overlayfs-grpc
-PKG_VERSION := github.com/AkihiroSuda/containerd-fuse-overlayfs/cmd/containerd-fuse-overlayfs-grpc/version
+PKG_MAIN := github.com/containerd/fuse-overlayfs-snapshotter/cmd/containerd-fuse-overlayfs-grpc
+PKG_VERSION := github.com/containerd/fuse-overlayfs-snapshotter/cmd/containerd-fuse-overlayfs-grpc/version
 
 GO ?= go
 export GO_BUILD=GO111MODULE=on CGO_ENABLED=0 $(GO) build -ldflags "-s -w -X $(PKG_VERSION).Version=$(VERSION) -X $(PKG_VERSION).Revision=$(REVISION)"

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,17 @@
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 DESTDIR ?= /usr/local
 
 VERSION=$(shell git describe --match 'v[0-9]*' --dirty='.m' --always --tags)

--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ with the following content, and recompile the containerd binary:
 
 package main
 
-// NOTE: the package name was "github.com/AkihiroSuda/containerd-fuse-overlayfs" before v1.0.0
-import _ "github.com/AkihiroSuda/containerd-fuse-overlayfs/plugin"
+import _ "github.com/containerd/fuse-overlayfs-snapshotter/plugin"
 ```
 
 No extra configuration is needed.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ You do NOT need this `fuse-overlayfs` plugin on the following environments, beca
 - [Debian 10 kernel](https://salsa.debian.org/kernel-team/linux/blob/283390e7feb21b47779b48e0c8eb0cc409d2c815/debian/patches/debian/overlayfs-permit-mounts-in-userns.patch)
   - Debian 10 needs `sudo modprobe overlay permit_mounts_in_userns=1`. Future release of Debian with kernel >= 5.11 will not need this `modprobe` hack.
 
+fuse-overlayfs-snapshotter is a **non-core** sub-project of containerd.
+
 ## Requirements
 * kernel >= 4.18
 * containerd >= 1.4
@@ -146,3 +148,12 @@ To run the test as a non-root user, [RootlessKit](https://github.com/rootless-co
 ```console
 $ go test -exec rootlesskit -test.v -test.root
 ```
+
+## Project details
+fuse-overlayfs-snapshotter is a containerd **non-core** sub-project, licensed under the [Apache 2.0 license](./LICENSE).
+As a containerd non-core sub-project, you will find the:
+ * [Project governance](https://github.com/containerd/project/blob/master/GOVERNANCE.md),
+ * [Maintainers](./MAINTAINERS),
+ * and [Contributing guidelines](https://github.com/containerd/project/blob/master/CONTRIBUTING.md)
+
+information in our [`containerd/project`](https://github.com/containerd/project) repository.

--- a/README.md
+++ b/README.md
@@ -29,10 +29,13 @@ with the following content, and recompile the containerd binary:
 ```go
 /*
    Copyright The containerd Authors.
+
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
+
        http://www.apache.org/licenses/LICENSE-2.0
+
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/cmd/containerd-fuse-overlayfs-grpc/main.go
+++ b/cmd/containerd-fuse-overlayfs-grpc/main.go
@@ -29,8 +29,8 @@ import (
 	snapshotsapi "github.com/containerd/containerd/api/services/snapshots/v1"
 	"github.com/containerd/containerd/contrib/snapshotservice"
 
-	fuseoverlayfs "github.com/AkihiroSuda/containerd-fuse-overlayfs"
-	"github.com/AkihiroSuda/containerd-fuse-overlayfs/cmd/containerd-fuse-overlayfs-grpc/version"
+	fuseoverlayfs "github.com/containerd/fuse-overlayfs-snapshotter"
+	"github.com/containerd/fuse-overlayfs-snapshotter/cmd/containerd-fuse-overlayfs-grpc/version"
 )
 
 // main is from https://github.com/containerd/containerd/blob/b9fad5e310fafb453def5f1e7094f4c36a9806d2/PLUGINS.md

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/AkihiroSuda/containerd-fuse-overlayfs
+module github.com/containerd/fuse-overlayfs-snapshotter
 
 go 1.16
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -21,9 +21,9 @@ package fuseoverlayfs
 import (
 	"errors"
 
-	fuseoverlayfs "github.com/AkihiroSuda/containerd-fuse-overlayfs"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/plugin"
+	fuseoverlayfs "github.com/containerd/fuse-overlayfs-snapshotter"
 )
 
 // Config represents configuration for the fuse-overlayfs plugin.


### PR DESCRIPTION
This plugin is already included in https://github.com/containerd/nerdctl , so we discussed moving this plugin along with nerdctl from `github.com/AkihiroSuda` to `github.com/containerd`

- - -

@dmcgowan @estesp (?) Could you rename this repo from `containerd-fuse-overlayfs` to `fuse-overlayfs-snapshotter`?
It seems I don't have a permission to do that.
