### PR TITLE
CI: fix handling push events

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,7 @@ name: CI
 on:
   workflow_dispatch:
   pull_request:
+  push:
     branches:
       - master
 jobs:


### PR DESCRIPTION
CI was not triggered on pushing to the master
