### PR TITLE
Remove references to io/ioutil package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,25 @@ jobs:
       with:
         working-directory: src/github.com/containerd/fuse-overlayfs-snapshotter
 
+  linters:
+    name: Linters
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      pull-requests: read # for golangci/golangci-lint-action to fetch pull requests
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: src/github.com/containerd/fuse-overlayfs-snapshotter
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.21.x
+      - uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.63.4
+          working-directory: src/github.com/containerd/fuse-overlayfs-snapshotter
+
   test:
     runs-on: ubuntu-22.04
     timeout-minutes: 30

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,25 @@
+linters:
+  enable:
+    - copyloopvar
+    - depguard
+    - gofmt
+    - gosec
+    - govet
+    - ineffassign
+    - misspell
+    - nolintlint
+    - staticcheck
+    - tenv
+    - unconvert
+    - unused
+  disable:
+    - errcheck
+    - revive
+
+linters-settings:
+  depguard:
+    rules:
+      main:
+        deny:
+          - pkg: "io/ioutil"
+            desc: use "io" or "os" instead

--- a/check.go
+++ b/check.go
@@ -21,7 +21,6 @@ package fuseoverlayfs
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -33,7 +32,7 @@ import (
 // supportsReadonlyMultipleLowerDir checks if read-only multiple lowerdirs can be mounted with fuse-overlayfs.
 // https://github.com/containers/fuse-overlayfs/pull/133
 func supportsReadonlyMultipleLowerDir(d string) error {
-	td, err := ioutil.TempDir(d, "fuseoverlayfs-check")
+	td, err := os.MkdirTemp(d, "fuseoverlayfs-check")
 	if err != nil {
 		return err
 	}

--- a/fuseoverlayfs.go
+++ b/fuseoverlayfs.go
@@ -22,7 +22,6 @@ package fuseoverlayfs
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -417,7 +416,7 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 }
 
 func (o *snapshotter) prepareDirectory(ctx context.Context, snapshotDir string, kind snapshots.Kind) (string, error) {
-	td, err := ioutil.TempDir(snapshotDir, "new-")
+	td, err := os.MkdirTemp(snapshotDir, "new-")
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp dir: %w", err)
 	}

--- a/fuseoverlayfs_test.go
+++ b/fuseoverlayfs_test.go
@@ -22,8 +22,6 @@ package fuseoverlayfs
 import (
 	"context"
 	_ "crypto/sha256"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/containerd/containerd/v2/core/snapshots"
@@ -42,11 +40,7 @@ func newSnapshotter(ctx context.Context, root string) (snapshots.Snapshotter, fu
 
 func TestFUSEOverlayFS(t *testing.T) {
 	testutil.RequiresRoot(t)
-	td, err := ioutil.TempDir("", "fuseoverlayfs-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(td)
+	td := t.TempDir()
 	if err := Supported(td); err != nil {
 		t.Skipf("fuse-overlayfs not supported: %v", err)
 	}


### PR DESCRIPTION
Package io/ioutil has been marked deprecated in Go 1.16.

Signed-off-by: Austin Vazquez <macedonv@amazon.com>