### PR TITLE
release.yaml: migrate from `hub` to `gh`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,11 +31,8 @@ jobs:
     - name: "Prepare the release note"
       working-directory:  go/src/github.com/containerd/fuse-overlayfs-snapshotter
       run: |
-        tag="${GITHUB_REF##*/}"
         shasha=$(sha256sum _output/SHA256SUMS | awk '{print $1}')
         cat <<-EOF | tee /tmp/release-note.txt
-        ${tag}
-
         (To be documented)
         - - -
         The binaries were built automatically on GitHub Actions.
@@ -49,6 +46,4 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         tag="${GITHUB_REF##*/}"
-        asset_flags=()
-        for f in _output/*; do asset_flags+=("-a" "$f"); done
-        hub release create "${asset_flags[@]}" -F /tmp/release-note.txt --draft "${tag}"
+        gh release create -F /tmp/release-note.txt --draft --title "${tag}" "${tag}" _output/*


### PR DESCRIPTION
`hub` was deprecated and removed from GitHub Actions runners:
- https://github.com/actions/runner-images/issues/8362