### PR TITLE
Added conversion logic for multiple id mapping snasphotter labels

### DIFF
--- a/fuseoverlayfs.go
+++ b/fuseoverlayfs.go
@@ -482,10 +482,10 @@ func (o *snapshotter) mounts(s storage.Snapshot, info snapshots.Info) []mount.Mo
 
 	options = append(options, fmt.Sprintf("lowerdir=%s", strings.Join(parentPaths, ":")))
 	if mapping, ok := info.Labels["containerd.io/snapshot/uidmapping"]; ok {
-		options = append(options, fmt.Sprintf("uidmapping=%s", mapping))
+		options = append(options, fmt.Sprintf("uidmapping=%s", convertIDMappingOption(mapping)))
 	}
 	if mapping, ok := info.Labels["containerd.io/snapshot/gidmapping"]; ok {
-		options = append(options, fmt.Sprintf("gidmapping=%s", mapping))
+		options = append(options, fmt.Sprintf("gidmapping=%s", convertIDMappingOption(mapping)))
 	}
 	return []mount.Mount{
 		{
@@ -508,4 +508,11 @@ func (o *snapshotter) workPath(id string) string {
 // Close closes the snapshotter
 func (o *snapshotter) Close() error {
 	return o.ms.Close()
+}
+
+// fuseIDMappingOption converts mapping entries joined with ',' to ':'
+// This is expected by the fuse-overlayfs program:
+// https://github.com/containers/fuse-overlayfs/blob/main/fuse-overlayfs.1.md
+func convertIDMappingOption(label string) string {
+	return strings.ReplaceAll(label, ",", ":")
 }


### PR DESCRIPTION
This PR add conversion logic for multiple id mapping snasphotter labels.

https://github.com/containerd/containerd/pull/10722 introduces the multiple uid/gid mappings to containerd. The mapping entries are passed to snapshotters as labels in the format of `0:1000:1,1:110000:65536`. Mappings are separated by `,`.

But `fuse-overlayfs` program requires mappings to be separated by `:` when passed as parameters.

This conversion logic ensures the mappings are passed along in the correct format.